### PR TITLE
fixing pagination in validators list.

### DIFF
--- a/src/actions/validators.js
+++ b/src/actions/validators.js
@@ -10,6 +10,7 @@ import {
 
 import helper from "../utils/helper";
 import transactions from "../utils/transactions";
+import Long from "long";
 
 export const fetchValidatorsInProgress = () => {
     return {
@@ -53,14 +54,14 @@ export const fetchValidatorsError = (count) => {
     };
 };
 
-const validatorsDelegationSort = (validators, delegations) =>{
-    let delegatedValidators =[];
+const validatorsDelegationSort = (validators, delegations) => {
+    let delegatedValidators = [];
     validators.forEach((item) => {
         for (const data of delegations) {
-            if(item.operatorAddress === data.delegation.validatorAddress){
+            if (item.operatorAddress === data.delegation.validatorAddress) {
                 let obj = {
-                    'data':item,
-                    'delegations':data.balance.amount*1
+                    'data': item,
+                    'delegations': data.balance.amount * 1
                 };
                 delegatedValidators.push(obj);
             }
@@ -81,6 +82,12 @@ export const fetchValidators = (address) => {
             const stakingQueryService = new QueryClientImpl(rpcClient);
             await stakingQueryService.Validators({
                 status: false,
+                pagination: {
+                    key: new Uint8Array(),
+                    offset: Long.fromNumber(0, true),
+                    limit: Long.fromNumber(125, true),
+                    countTotal: true
+                }
             }).then(async (res) => {
                 let validators = res.validators;
                 let activeValidators = [];


### PR DESCRIPTION
## 1. Overview

Validators list increased to 103 causing AUDIT.one and a few other validators to be dropped out of the default query list.

## 2. Implementation details

- Have increased limit to fetch 125 validators entries.

## 3. How to test/use
- can see query results from network, or console it.

## 4. Limitations (optional)

_Limitation of the capabilities described in the Overview section, if
applicable_

- Will again fail if validator list crosses 125.

## 5. Future Work (optional)

_Potential follow up work, if applicable_

- Paginate the query, so all validators are requested in an efficient manner. 
- Use next key function to query results 

